### PR TITLE
Bugfix/order nrv

### DIFF
--- a/pupynere.py
+++ b/pupynere.py
@@ -1053,7 +1053,7 @@ class NcOrderedDict(OrderedDict):
                 if not v or v.data is None or len(v.shape) == 0:
                     return 0
                 else:
-                    return v.itemsize * reduce(lambda a, b: a * b, v.shape)
+                    return v.itemsize * np.prod(v.shape)
             nonrecvars.sort(key=lambda v: variableDiskSize(v[1]))
 
             for key in self.keys():

--- a/pupynere.py
+++ b/pupynere.py
@@ -1050,7 +1050,10 @@ class NcOrderedDict(OrderedDict):
             recvars = [v for v in items if v[1].isrec]
             nonrecvars = [v for v in items if not v[1].isrec]
             def variableDiskSize(v):
-                return v.itemsize * reduce(lambda a, b: a * b, v.shape)
+                if not v or v.data is None or len(v.shape) == 0:
+                    return 0
+                else:
+                    return v.itemsize * reduce(lambda a, b: a * b, v.shape)
             nonrecvars.sort(key=lambda v: variableDiskSize(v[1]))
 
             for key in self.keys():


### PR DESCRIPTION
Resolves https://github.com/pacificclimate/pydap.responses.netcdf/issues/7

Orders nonrecord variables in `NcOrderedDict`, the canonical list of variables in the file to be created. Nonrecord variables will be listed in ascending order of size on disk, followed by record variables (if any). This reflects the order variables should be written in the [netCDF 64-bit offset standards](https://www.unidata.ucar.edu/software/netcdf/netcdf/NetCDF-64-bit-Offset-Format-Limitations.html#NetCDF-64-bit-Offset-Format-Limitations):

> No fixed-size variable can require more than 2^32 - 4 bytes (i.e. 4GiB - 4 bytes, or 4,294,967,292 bytes) of storage for its data, unless it is the last fixed-size variable and there are no record variables. When there are no record variables, the last fixed-size variable can be any size supported by the file system, e.g. terabytes. 

Previously, variable order in files was nonrecord variables in any order, followed by record variables. Files were sometimes generated with a variable like latitude or longitude occurring later in the file than the main variable (tasmax, tasmin, pr) even when the main variable was more than 4GB in size.

The `.variables` attribute of the `netcdf_file` class is an `NcOrderedDict`, so setting the correct variable order in `NcOrderedDict` results in every package that uses `netcdf_file.variables`, (like pydap.responses.netcdf) writing variables in accordance with the 64 bit offset standard.