### PR TITLE
Fix MemoryError in large downloads

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,0 +1,57 @@
+News / Release Notes
+====================
+
+1.1.5
+-----
+*Release Date: 15-Apr-2019*
+
+* Fix handling of record variables with no data
+* Order nonrecord variables by size within the file
+
+1.1.4
+-----
+*Release Date: 16-March-2019*
+
+* Variable padding fixes
+
+1.1.3
+-----
+*Release Date: 30-March-2015*
+
+* Fix infinite loop when files only have non record variables
+* Logging improvements
+
+
+1.1.2a2
+------
+*Release Date: 23-March-2014*
+
+* Error checking
+* Created test suite
+* Fix bug related to vsize
+
+
+1.1.2a1
+-------
+*Release Date: 20-March-2013*
+
+* Allow creation of virtual-only netCDFs
+* Allow filesize determination without data
+
+1.1.2
+-----
+*Release Date: 04-March-2013*
+
+* Fix a bug related to types
+
+1.1.1
+-----
+*Release Date: 15-January-2013*
+
+* Generator-ize netCDF creation code
+
+1.1.0
+------
+*Release Date: 10-April-2011*
+
+* Initial fork

--- a/README.md
+++ b/README.md
@@ -1,30 +1,25 @@
-Pupynere-pdp: netCDF streaming for the PCIC Data Portal
-=======================================================
+# Pupynere-pdp: netCDF streaming for the PCIC Data Portal
 
 This module is a fork of pupynere, a lightweight netCDF reading and writing 
-module. It has been modified for use in the `PCIC Data Portal 
-<https://github.com/pacificclimate/pdp>`. In the context of the PDP, it is used to
+module. It has been modified for use in the [PCIC Data Portal](https://github.com/pacificclimate/pdp). In the context of the PDP, it is used to
 write and stream the headers and metadata of netCDF files as users download them.
-The PDP ecosystem uses `a different package
-<https://github.com/pacificclimate/pydap.handlers.hdf5>` to read the data from the
+The PDP ecosystem uses [a different package](https://github.com/pacificclimate/pydap.handlers.hdf5) to read the data from the
 master file for streaming. PCIC's modifications for streaming netCDF files include:
-# calculate the filesize before the file is created so it can be sent as a
-  content-length header
-# generator pattern so data can be sent in small chunks as it is ready
-# allow creation of virtual files in memory, not the filesystem
-# NcOrderedDict class for synchronizing variable order across multiple generators
-# Memory for variable data is not allocated until needed
+* calculate the filesize before the file is created so it can be sent as a content-length header
+* generator pattern so data can be sent in small chunks as it is ready
+* allow creation of virtual files in memory, not the filesystem
+* NcOrderedDict class for synchronizing variable order across multiple generators
+* Memory for variable data is not allocated until needed
 
 This package hews closely to the 
-`NetCDF file format specification <http://www.unidata.ucar.edu/software/netcdf/guide_15.html>`_, 
+[NetCDF file format specification](http://www.unidata.ucar.edu/software/netcdf/guide_15.html), 
 which should be considered supplementary documentation. Most functions are named
 for the part of the NetCDF file spec they or write.
 
 
-Package Overview
-----------------
+## Package Overview
 
--netcdf_file
+### netcdf_file
   This class represents a netCDF file.
   It may be initialized with a filename, a file pointer, or neither. If initialized
   with some kind of file representation, it will read and write data to the filesystem,
@@ -32,34 +27,34 @@ Package Overview
   option.
   Arbitrary attributes may be set on a netcdf_file object and will be treated as global
   attributes when the file is streamed or written to disk.
-  - filesize() - projected or actual size of the file. Can be calculated before the file
+  - `filesize()` - projected or actual size of the file. Can be calculated before the file
   is fully populated to send to a downloader as the content-length header, based on the 
   variable, dimension, and record specifications. No actual data needed.
-  - close() - close the file pointer, if there is one.
-  - createDimension() and createVariable() - add dimensions or variables to the file
-  - flush() - flush to disk. Only relevant for files on the filesystem
-  - recvars() and nonrecvars() - get an ordered dictionary of the record or nonrecord 
+  - `close()` - close the file pointer, if there is one.
+  - `createDimension()` and `createVariable()` - add dimensions or variables to the file
+  - `flush()` - flush to disk. Only relevant for files on the filesystem
+  - `recvars()` and `nonrecvars()` - get an ordered dictionary of the record or nonrecord 
     variables in this file
-  - __generate__() - get this file as generator chunks
-  - _write() - write the netCDF file to disk. Only relevant for files on the filesystem
-  - _header(), _data(), _dim_array(), _gatt_array(), _var_array(), _att_array(), _num_recs(), _var_metadata()
+  - `__generate__()` - get this file as generator chunks
+  - `_write()` - write the netCDF file to disk. Only relevant for files on the filesystem
+  - `_header()`, `_data()`, `_dim_array()`, `_gatt_array()`, `_var_array()`, `_att_array()`, `_num_recs()`, `_var_metadata()`
     get the various parts of a netCDF file, encoded per the netCDF specification. Helper
-    functions to _write() and __generate__(). Reading the netCDF spec is helpful for
+    functions to `_write()` and `__generate__()`. Reading the netCDF spec is helpful for
     understanding the use of each of these functions; their names match up.
-  - _read() - read a netCDF file from the filesystem
-  - _read_values(), _read_dim_array(), read_gatt_array(), read_var_array(), _read_att_array(), _read_num_recs(), _read_var_values()
+  - `_read()` - read a netCDF file from the filesystem
+  - `_read_values()`, `_read_dim_array()`, `read_gatt_array()`, `read_var_array()`, `_read_att_array()`, `_read_num_recs()`, `_read_var_values()`
     read part of a netCDF file from the filesystem, following the netCDF spec. Helper functions
     to _read(). Reading the netCDF spec is helpful for understanding the use of each of 
     these functions; their names match up. Not used by the PDP. 
-  - _calc_begins() - calculates the starting address of each variable. Essential for
+  - `_calc_begins()` - calculates the starting address of each variable. Essential for
     streaming data if you want to send the header before you have all the variable data.
-  - set_numrecs() - set the number of records in the datafile without actually assigning the
+  - `set_numrecs()` - set the number of records in the datafile without actually assigning the
     data. Used for streaming data to send the filesize and complete headers before all
     data is available.
-  - _pack_begin(), _pack_int(), _pack_int_64(), _pack_string()
+  - `_pack_begin()`, `_pack_int()`, `_pack_int_64()`, `_pack_string()`
     return an integer or string in the correct format for a netCDF file. Helpers to
     the file-writing or file-generator functions. NetCDF is big-endian
-  - _unpack_int(), _unpack_int64(), unpack_string()
+  - `_unpack_int()`, `_unpack_int64()`, `unpack_string()`
     read the file and translate an integer or string. Helpers to the _read functions
   PDP Usage: To create headers for streaming, the PDP (via pydap.responses.netcdf) creates
   a new, virtual netCDF file with the dimensions and variables requested by the user, and
@@ -70,7 +65,7 @@ Package Overview
   the headers. A NcOrderedDict is used to synchronize the order of the variables in
   the header generated here and the data generated by pydap.handlers.hd5.
 
--netcdf_variable
+### netcdf_variable
   This class represents a single netCDF variable within a file. Arbitrary attributes
   may be set on a netcdf_variable attribute, and will be treated as variable attributes
   when the variable is streamed or written to disk.
@@ -85,61 +80,60 @@ Package Overview
   portions.  Many things are handled differently depending on whether a variable is a
   record or nonrecord variable. See the "More information on NetCDF" section or the 
   netCDF specification for more information.
-  - isrec() returns true if this is a record variable
-  - shape() the current numerical dimensions of the variable
-  - getValue() and assignValue() a netCDF variable may have no associated dimensions
+  - `isrec()` returns true if this is a record variable
+  - `shape()` the current numerical dimensions of the variable
+  - `getValue()` and `assignValue()` a netCDF variable may have no associated dimensions
     and represent a scalar value. These functions access and set such a variable.
-  - __getitem__() and __setitem__() - numpy-style assignment and data access
-  - typecode() the type of the variable
-  - itemsize() the number of bytes a single datum occupies, ie 4 for an integer
-  - size() the total number of values in this variable (or potential values - can be
+  - `__getitem__()` and `__setitem__()` - numpy-style assignment and data access
+  - `typecode()` the type of the variable's data
+  - `itemsize()` the number of bytes a single datum occupies, ie 4 for an integer
+  - `size()` the total number of values in this variable (or potential values - can be
     calculated without setting any data just from the dimensions and number of records, 
     which is done when streaming)
-  - _data_allocated() and _set_data() Because the primary use of this package is just
+  - `_data_allocated()` and `_set_data()` Because the primary use of this package is just
     to generate file headers, memory to hold variable data is not automatically allocated.
     These functions check whether memory has been allocated and allocate it.
     Memory is typically allocated the first time data is written to the variable.
--NcOrderedDict
-  - an ordered dictionary of the variables inside a netCDF file. Used by pydap to
-    coordinate the order pupynere lists variables in the header and the order blocks
-    of data are streamed by pydap.handlers.hd5. Can be either nonrecord, record,
-    or all variables. In the case of all variables, nonrecord variables ordered by
-    ascending size, then record variables.
-- coroutine()
-  - not currently used
-- byteorderer() 
-  - not currently used
-- check_byteorder()
-  - not currently used
-- nc_streamer()
-  - not currently used
-- nc_generator()
-  - generator that yields the headers of a netCDF file, then yields from additional
-    generator(s) representing the data
-- nc_writer()
-  - not currently used
-- TYPEMAP() and REVERSE()
-  - map from netCDF types to numpy types and vice versa, respctively.  
+### NcOrderedDict
+  An ordered dictionary of the variables inside a netCDF file. Used by pydap to
+  coordinate the order pupynere lists variables in the header and the order blocks
+  of data are streamed by pydap.handlers.hd5. Can be either nonrecord, record,
+  or all variables. In the case of all variables, nonrecord variables ordered by
+  ascending size, then record variables.
+### coroutine()
+  Nnot currently used
+### byteorderer() 
+  Not currently used
+### check_byteorder()
+  Not currently used
+### nc_streamer()
+  Not currently used
+### nc_generator()
+  Generator that yields the headers of a netCDF file, then yields from additional 
+  generator(s) representing the data
+### nc_writer()
+  Not currently used
+### TYPEMAP() and REVERSE()
+  Map from netCDF types to numpy types and vice versa, respctively.  
   
-Running Tests
--------------
+## Running Tests
+
 Tests can be run with pytest.
 
-.. code:: bash
+```bash
    virtualenv venv
    source venv/bin/activate
    pip install .
    pip install pytest
    pytest
+```
+## Creating non-virtual netCDF files 
 
-Creating non-virtual netCDF files 
----------------------------------
-
-Seperate from the streaming workflow described above, this package can be used to create
+Differently from the streaming workflow described above, this package can be used to create
 netCDF files on the filesystem, which may be useful for testing.
 
-To create a NetCDF file::
-
+To create a NetCDF file
+```python
     >>> f = netcdf_file('simple.nc', 'w')
     >>> f.history = 'Created for a test'
     >>> f.createDimension('time', 10)
@@ -147,9 +141,10 @@ To create a NetCDF file::
     >>> time[:] = range(10)
     >>> time.units = 'days since 2008-01-01'
     >>> f.close()
+```
 
-To read the NetCDF file we just created::
-
+To read the NetCDF file we just created
+```python
     >>> f = netcdf_file('simple.nc', 'r')
     >>> print f.history
     Created for a test
@@ -161,28 +156,25 @@ To read the NetCDF file we just created::
     >>> print time[-1]
     9
     >>> f.close()
+```
 
+## More information on NetCDF 
 
-More information on NetCDF 
---------------------------
+This module implements the Scientific.IO.NetCDF API to read and create NetCDF files. The same API is also used in the PyNIO and pynetcdf modules, allowing these modules to be used interchangebly when working with NetCDF files. The major advantage of `scipy.io.netcdf` over other modules is that it doesn't require the code to be linked to the NetCDF libraries as the other modules do.
 
-This module implements the Scientific.IO.NetCDF API to read and create NetCDF files. The same API is also used in the PyNIO and pynetcdf modules, allowing these modules to be used interchangebly when working with NetCDF files. The major advantage of ``scipy.io.netcdf`` over other modules is that it doesn't require the code to be linked to the NetCDF libraries as the other modules do.
+The code is based on the [NetCDF file format specification](http://www.unidata.ucar.edu/software/netcdf/guide_15.html). A NetCDF file is a self-describing binary format, with a header followed by data. The header contains metadata describing dimensions, variables and the position of the data in the file, so access can be done in an efficient manner without loading unnecessary data into memory. We use the `mmap` module to create Numpy arrays mapped to the data on disk, for the same purpose.
 
-The code is based on the `NetCDF file format specification <http://www.unidata.ucar.edu/software/netcdf/guide_15.html>`_. A NetCDF file is a self-describing binary format, with a header followed by data. The header contains metadata describing dimensions, variables and the position of the data in the file, so access can be done in an efficient manner without loading unnecessary data into memory. We use the ``mmap`` module to create Numpy arrays mapped to the data on disk, for the same purpose.
-
-The structure of a NetCDF file is as follows::
-
+The structure of a NetCDF file is as follows
+```
     C D F <VERSION BYTE> <NUMBER OF RECORDS>
     <DIMENSIONS> <GLOBAL ATTRIBUTES> <VARIABLES METADATA>
     <NON-RECORD DATA> <RECORD DATA>
-
+```
 Record data refers to data where the first axis can be expanded at will. All record variables share a same dimension at the first axis, and they are stored at the end of the file per record, ie
 
-::
-
+```
     A[0], B[0], ..., A[1], B[1], ..., etc,
-    
+```    
 so that new data can be appended to the file without changing its original structure. Non-record data are padded to a 4n bytes boundary. Record data are also padded, unless there is exactly one record variable in the file, in which case the padding is dropped.  All data is stored in big endian byte order.
 
-The Scientific.IO.NetCDF API allows attributes to be added directly to instances of ``netcdf_file`` and ``netcdf_variable``. To differentiate between user-set attributes and instance attributes, user-set attributes are automatically stored in the ``_attributes`` attribute by overloading ``__setattr__``. This is the reason why the code sometimes uses ``obj.__dict__['key'] = value``, instead of simply ``obj.key = value``; otherwise the key would be inserted into userspace attributes.
-
+The Scientific.IO.NetCDF API allows attributes to be added directly to instances of `netcdf_file` and `netcdf_variable`. To differentiate between user-set attributes and instance attributes, user-set attributes are automatically stored in the `_attributes` attribute by overloading `__setattr__`. This is the reason why the code sometimes uses `obj.__dict__['key'] = value`, instead of simply `obj.key = value`; otherwise the key would be inserted into userspace attributes.

--- a/README.rst
+++ b/README.rst
@@ -1,25 +1,142 @@
-NetCDF reader/writer module.
-============================
+Pupynere-pdp: netCDF streaming for the PCIC Data Portal
+=======================================================
 
-This module implements the Scientific.IO.NetCDF API to read and create NetCDF files. The same API is also used in the PyNIO and pynetcdf modules, allowing these modules to be used interchangebly when working with NetCDF files. The major advantage of ``scipy.io.netcdf`` over other modules is that it doesn't require the code to be linked to the NetCDF libraries as the other modules do.
+This module is a fork of pupynere, a lightweight netCDF reading and writing 
+module. It has been modified for use in the `PCIC Data Portal 
+<https://github.com/pacificclimate/pdp>`. In the context of the PDP, it is used to
+write and stream the headers and metadata of netCDF files as users download them.
+The PDP ecosystem uses `a different package
+<https://github.com/pacificclimate/pydap.handlers.hdf5>` to read the data from the
+master file for streaming. PCIC's modifications for streaming netCDF files include:
+# calculate the filesize before the file is created so it can be sent as a
+  content-length header
+# generator pattern so data can be sent in small chunks as it is ready
+# allow creation of virtual files in memory, not the filesystem
+# NcOrderedDict class for synchronizing variable order across multiple generators
+# Memory for variable data is not allocated until needed
 
-The code is based on the `NetCDF file format specification <http://www.unidata.ucar.edu/software/netcdf/guide_15.html>`_. A NetCDF file is a self-describing binary format, with a header followed by data. The header contains metadata describing dimensions, variables and the position of the data in the file, so access can be done in an efficient manner without loading unnecessary data into memory. We use the ``mmap`` module to create Numpy arrays mapped to the data on disk, for the same purpose.
+This package hews closely to the 
+`NetCDF file format specification <http://www.unidata.ucar.edu/software/netcdf/guide_15.html>`_, 
+which should be considered supplementary documentation. Most functions are named
+for the part of the NetCDF file spec they or write.
 
-The structure of a NetCDF file is as follows::
 
-    C D F <VERSION BYTE> <NUMBER OF RECORDS>
-    <DIMENSIONS> <GLOBAL ATTRIBUTES> <VARIABLES METADATA>
-    <NON-RECORD DATA> <RECORD DATA>
+Package Overview
+----------------
 
-Record data refers to data where the first axis can be expanded at will. All record variables share a same dimension at the first axis, and they are stored at the end of the file per record, ie
+-netcdf_file
+  This class represents a netCDF file.
+  It may be initialized with a filename, a file pointer, or neither. If initialized
+  with some kind of file representation, it will read and write data to the filesystem,
+  otherwise it will be virtual file resident in virtual memory. The PDP uses the virtual
+  option.
+  Arbitrary attributes may be set on a netcdf_file object and will be treated as global
+  attributes when the file is streamed or written to disk.
+  - filesize() - projected or actual size of the file. Can be calculated before the file
+  is fully populated to send to a downloader as the content-length header, based on the 
+  variable, dimension, and record specifications. No actual data needed.
+  - close() - close the file pointer, if there is one.
+  - createDimension() and createVariable() - add dimensions or variables to the file
+  - flush() - flush to disk. Only relevant for files on the filesystem
+  - recvars() and nonrecvars() - get an ordered dictionary of the record or nonrecord 
+    variables in this file
+  - __generate__() - get this file as generator chunks
+  - _write() - write the netCDF file to disk. Only relevant for files on the filesystem
+  - _header(), _data(), _dim_array(), _gatt_array(), _var_array(), _att_array(), _num_recs(), _var_metadata()
+    get the various parts of a netCDF file, encoded per the netCDF specification. Helper
+    functions to _write() and __generate__(). Reading the netCDF spec is helpful for
+    understanding the use of each of these functions; their names match up.
+  - _read() - read a netCDF file from the filesystem
+  - _read_values(), _read_dim_array(), read_gatt_array(), read_var_array(), _read_att_array(), _read_num_recs(), _read_var_values()
+    read part of a netCDF file from the filesystem, following the netCDF spec. Helper functions
+    to _read(). Reading the netCDF spec is helpful for understanding the use of each of 
+    these functions; their names match up. Not used by the PDP. 
+  - _calc_begins() - calculates the starting address of each variable. Essential for
+    streaming data if you want to send the header before you have all the variable data.
+  - set_numrecs() - set the number of records in the datafile without actually assigning the
+    data. Used for streaming data to send the filesize and complete headers before all
+    data is available.
+  - _pack_begin(), _pack_int(), _pack_int_64(), _pack_string()
+    return an integer or string in the correct format for a netCDF file. Helpers to
+    the file-writing or file-generator functions. NetCDF is big-endian
+  - _unpack_int(), _unpack_int64(), unpack_string()
+    read the file and translate an integer or string. Helpers to the _read functions
+  PDP Usage: To create headers for streaming, the PDP (via pydap.responses.netcdf) creates
+  a new, virtual netCDF file with the dimensions and variables requested by the user, and
+  global and variable attributes read from the source netCDF file. Then the number of
+  records is set and the variable begin addresses are calculated. Then the header can
+  be generated and streamed to the downloader. A pydap handler package streams the data
+  from the source file; it is never added to this virtual netcdf file used to generate
+  the headers. A NcOrderedDict is used to synchronize the order of the variables in
+  the header generated here and the data generated by pydap.handlers.hd5.
 
-::
+-netcdf_variable
+  This class represents a single netCDF variable within a file. Arbitrary attributes
+  may be set on a netcdf_variable attribute, and will be treated as variable attributes
+  when the variable is streamed or written to disk.
+  Data may be written to a net_cdf variable using square bracket notation as if it was
+  a numpy array.
+  A variable is either a record variable or a nonrecord variable; they two types are
+  formatted differently when written to disk or streamed. Nonrecord variables have all
+  dimensions of known size and are written to disk or stream in a continuous block. Record
+  variables have one dimension (the record dimension) that is expected to change over time.
+  All record variables are written at the end of the file, interleaved so that if more
+  records are added, the file is simply appended to without needing to rewrite earlier
+  portions.  Many things are handled differently depending on whether a variable is a
+  record or nonrecord variable. See the "More information on NetCDF" section or the 
+  netCDF specification for more information.
+  - isrec() returns true if this is a record variable
+  - shape() the current numerical dimensions of the variable
+  - getValue() and assignValue() a netCDF variable may have no associated dimensions
+    and represent a scalar value. These functions access and set such a variable.
+  - __getitem__() and __setitem__() - numpy-style assignment and data access
+  - typecode() the type of the variable
+  - itemsize() the number of bytes a single datum occupies, ie 4 for an integer
+  - size() the total number of values in this variable (or potential values - can be
+    calculated without setting any data just from the dimensions and number of records, 
+    which is done when streaming)
+  - _data_allocated() and _set_data() Because the primary use of this package is just
+    to generate file headers, memory to hold variable data is not automatically allocated.
+    These functions check whether memory has been allocated and allocate it.
+    Memory is typically allocated the first time data is written to the variable.
+-NcOrderedDict
+  - an ordered dictionary of the variables inside a netCDF file. Used by pydap to
+    coordinate the order pupynere lists variables in the header and the order blocks
+    of data are streamed by pydap.handlers.hd5. Can be either nonrecord, record,
+    or all variables. In the case of all variables, nonrecord variables ordered by
+    ascending size, then record variables.
+- coroutine()
+  - not currently used
+- byteorderer() 
+  - not currently used
+- check_byteorder()
+  - not currently used
+- nc_streamer()
+  - not currently used
+- nc_generator()
+  - generator that yields the headers of a netCDF file, then yields from additional
+    generator(s) representing the data
+- nc_writer()
+  - not currently used
+- TYPEMAP() and REVERSE()
+  - map from netCDF types to numpy types and vice versa, respctively.  
+  
+Running Tests
+-------------
+Tests can be run with pytest.
 
-    A[0], B[0], ..., A[1], B[1], ..., etc,
-    
-so that new data can be appended to the file without changing its original structure. Non-record data are padded to a 4n bytes boundary. Record data are also padded, unless there is exactly one record variable in the file, in which case the padding is dropped.  All data is stored in big endian byte order.
+.. code:: bash
+   virtualenv venv
+   source venv/bin/activate
+   pip install .
+   pip install pytest
+   pytest
 
-The Scientific.IO.NetCDF API allows attributes to be added directly to instances of ``netcdf_file`` and ``netcdf_variable``. To differentiate between user-set attributes and instance attributes, user-set attributes are automatically stored in the ``_attributes`` attribute by overloading ``__setattr__``. This is the reason why the code sometimes uses ``obj.__dict__['key'] = value``, instead of simply ``obj.key = value``; otherwise the key would be inserted into userspace attributes.
+Creating non-virtual netCDF files 
+---------------------------------
+
+Seperate from the streaming workflow described above, this package can be used to create
+netCDF files on the filesystem, which may be useful for testing.
 
 To create a NetCDF file::
 
@@ -44,3 +161,28 @@ To read the NetCDF file we just created::
     >>> print time[-1]
     9
     >>> f.close()
+
+
+More information on NetCDF 
+--------------------------
+
+This module implements the Scientific.IO.NetCDF API to read and create NetCDF files. The same API is also used in the PyNIO and pynetcdf modules, allowing these modules to be used interchangebly when working with NetCDF files. The major advantage of ``scipy.io.netcdf`` over other modules is that it doesn't require the code to be linked to the NetCDF libraries as the other modules do.
+
+The code is based on the `NetCDF file format specification <http://www.unidata.ucar.edu/software/netcdf/guide_15.html>`_. A NetCDF file is a self-describing binary format, with a header followed by data. The header contains metadata describing dimensions, variables and the position of the data in the file, so access can be done in an efficient manner without loading unnecessary data into memory. We use the ``mmap`` module to create Numpy arrays mapped to the data on disk, for the same purpose.
+
+The structure of a NetCDF file is as follows::
+
+    C D F <VERSION BYTE> <NUMBER OF RECORDS>
+    <DIMENSIONS> <GLOBAL ATTRIBUTES> <VARIABLES METADATA>
+    <NON-RECORD DATA> <RECORD DATA>
+
+Record data refers to data where the first axis can be expanded at will. All record variables share a same dimension at the first axis, and they are stored at the end of the file per record, ie
+
+::
+
+    A[0], B[0], ..., A[1], B[1], ..., etc,
+    
+so that new data can be appended to the file without changing its original structure. Non-record data are padded to a 4n bytes boundary. Record data are also padded, unless there is exactly one record variable in the file, in which case the padding is dropped.  All data is stored in big endian byte order.
+
+The Scientific.IO.NetCDF API allows attributes to be added directly to instances of ``netcdf_file`` and ``netcdf_variable``. To differentiate between user-set attributes and instance attributes, user-set attributes are automatically stored in the ``_attributes`` attribute by overloading ``__setattr__``. This is the reason why the code sometimes uses ``obj.__dict__['key'] = value``, instead of simply ``obj.key = value``; otherwise the key would be inserted into userspace attributes.
+

--- a/pupynere.py
+++ b/pupynere.py
@@ -359,8 +359,6 @@ class netcdf_file(object):
         # Justification: the standard PCIC usage of this package is solely to generate
         #    headers for a streamable netCDF file. Variable data is never used and,
         #    if initialized, will take up large volumes of unnecesary memory.
-
-        #data = empty(shape_, type)
         data = empty(shape_, type) if isrec else None
 
         self.variables[name] = netcdf_variable(
@@ -924,7 +922,6 @@ class netcdf_variable(object):
 
         """
         return self._isrec
-        # return (hasattr(self.data, 'shape') and self.data.shape) and (not self._shape[0])
     isrec = property(isrec)
 
     def shape(self):
@@ -934,7 +931,6 @@ class netcdf_variable(object):
         same manner of other numpy arrays.
         """
         return self._shape if self.data is None else self.data.shape
-        # return self.data.shape
     shape = property(shape)
 
     def getValue(self):

--- a/pupynere.py
+++ b/pupynere.py
@@ -877,6 +877,8 @@ class netcdf_variable(object):
         become attributes for the netcdf_variable object.
     maskandscale: True or False
         Whether data is automagically scaled and masked.
+    isrec: True or False
+        Whether this is a record variable (first dimension unlimited)
 
 
     Attributes
@@ -930,7 +932,7 @@ class netcdf_variable(object):
         This is a read-only attribute and can not be modified in the
         same manner of other numpy arrays.
         """
-        return self._shape if self.data is None else self.data.shape
+        return self._shape if not self._data_allocated() else self.data.shape
     shape = property(shape)
 
     def getValue(self):
@@ -1004,7 +1006,7 @@ class netcdf_variable(object):
 
     def __getitem__(self, index):
         
-        if self.data is None:
+        if not self._data_allocated():
             raise ValueError("Cannot access uninitialized data.")
         # scalar
         if not self.shape:
@@ -1066,7 +1068,7 @@ class netcdf_variable(object):
         self.data = empty(self.shape, self.dtype)
     
     def size(self):
-        return np.prod(self.shape) if self.data is None else self.data.size
+        return np.prod(self.shape) if not self._data_allocated() else self.data.size
     size = property(size)
 
 from collections import OrderedDict

--- a/pupynere.py
+++ b/pupynere.py
@@ -410,7 +410,7 @@ class netcdf_file(object):
     def _data(self):
         if self.variables:
             for var in self.variables.values():
-                if not var.data:
+                if var.data is None:
                     raise ValueError("Cannot write variable with unallocated data")
                 if (var.data.dtype.byteorder == '<' or
                     (var.data.dtype.byteorder == '=' and LITTLE_ENDIAN)):
@@ -933,7 +933,7 @@ class netcdf_variable(object):
         This is a read-only attribute and can not be modified in the
         same manner of other numpy arrays.
         """
-        return self.data.shape if self.data else self._shape
+        return self._shape if self.data is None else self.data.shape
         # return self.data.shape
     shape = property(shape)
 
@@ -1008,7 +1008,7 @@ class netcdf_variable(object):
 
     def __getitem__(self, index):
         
-        if not self.data:
+        if self.data is None:
             raise ValueError("Cannot access uninitialized data.")
         # scalar
         if not self.shape:
@@ -1070,7 +1070,7 @@ class netcdf_variable(object):
         self.data = empty(self.shape, self.dtype)
     
     def size(self):
-        return self.data.size if self.data else np.prod(self.shape)
+        return np.prod(self.shape) if self.data is None else self.data.size
     size = property(size)
 
 from collections import OrderedDict

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -43,6 +43,10 @@ class AttributesTestCase(unittest.TestCase):
         v.intatt = INTATT
         v.floatatt = FLOATATT
         v.seqatt = SEQATT
+        
+        data = NP.empty(shape=(DIM1_LEN,DIM2_LEN,DIM3_LEN))
+        v[:] = data
+
 
         f.close()
 


### PR DESCRIPTION
Resolves #3 

The MemoryError was caused by the allocation of a large, static chunk of memory in the form of a numpy array whenever a new `netcdf_variable` was created. The purpose of the array was to hold the data of the variable.

However, in the normal course of PDP operations, this huge memory-eating array is never actually _used_. `pydap-pdp` uses this package solely to create the headers for a netCDF file that the user is requesting. Actual data is provided by the `pydap.handlers.hd5` package instead, to take advantage of its fast hd5 access.

This PR changes when the data array is allocated. Instead of being allocated when a new variable is created, it is now allocated the first time data is written to a variable. (This never happen as part of the PDP.)

A few variable properties of netcdf_variable (`isrec`, `size`) have been changed, as they can no longer be calculated from the `.data` attribute. Direct access to `netcdf_variable.data` by the `netcdf_file` for shape/size metadata have been rewritten to use other attributes.